### PR TITLE
Release: OAS2Apigee Build Profile

### DIFF
--- a/build-profiles/api-proxies/oas2apigee/v1.yaml
+++ b/build-profiles/api-proxies/oas2apigee/v1.yaml
@@ -1,0 +1,35 @@
+parameters:
+  - name: buildProfile
+    type: object
+  - name: preBuildStageName
+    type: string
+  - name: preBuildStageDisplayName
+    type: string
+  - name: buildStageName
+    type: string
+  - name: buildStageDisplayName
+    type: string
+  - name: variableGroups
+    type: object
+
+stages:
+  - stage: ${{ parameters.preBuildStageName }}
+    displayName: ${{ parameters.preBuildStageDisplayName }}
+    jobs:
+      - template: ../../../job-groups/systems-checks.yaml
+        parameters:
+          buildProfile: ${{ parameters.buildProfile }}
+
+  - stage: ${{ parameters.buildStageName }}
+    displayName: ${{ parameters.buildStageDisplayName }}
+    condition: |
+      succeeded('${{ parameters.preBuildStageName }}')
+    dependsOn:
+      - ${{ parameters.preBuildStageName }}
+    variables:
+      - ${{ each variableGroup in parameters.variableGroups }}:
+          - group: ${{ variableGroup }}
+    jobs:
+      - template: ../../../job-groups/custom-build.yaml
+        parameters:
+          buildProfile: ${{ parameters.buildProfile }}      

--- a/build.yaml
+++ b/build.yaml
@@ -29,7 +29,7 @@ resources:
       # TODO uncomment when work is done
       # ref: main
       # TODO remove when development is done
-      ref: feat/oas2apigee-build-profile
+      ref: rel/framework-v2.0.0
       endpoint: ShehabEl-DeenAlalkamy
 
 extends:

--- a/build.yaml
+++ b/build.yaml
@@ -29,7 +29,7 @@ resources:
       # TODO uncomment when work is done
       # ref: main
       # TODO remove when development is done
-      ref: rel/framework-v2.0.0
+      ref: feat/oas2apigee-build-profile
       endpoint: ShehabEl-DeenAlalkamy
 
 extends:

--- a/job-groups/custom-build.yaml
+++ b/job-groups/custom-build.yaml
@@ -5,3 +5,6 @@ parameters:
 jobs:
   - ${{ if eq(parameters.buildProfile.name, 'mvn-plugins') }}:
       - template: ../jobs/apigee-mvn-plugin.yaml
+
+  - ${{ if eq(parameters.buildProfile.name, 'oas2apigee') }}:
+      - template: ../jobs/oas2apigee.yaml

--- a/jobs/oas2apigee.yaml
+++ b/jobs/oas2apigee.yaml
@@ -1,0 +1,74 @@
+parameters:
+  - name: jobName
+    type: string
+    default: OAS2Apigee
+  - name: displayName
+    type: string
+    default: OAS2Apigee
+  - name: dependsOn
+    type: object
+    default: []
+  - name: mandatoryTasks
+    type: stepList
+    default: []
+
+jobs:
+  - job: ${{ parameters.jobName }}
+    displayName: ${{ parameters.displayName }}
+    dependsOn:
+      - ${{ each dependency in parameters.dependsOn }}:
+          - ${{ dependency }}
+    steps:
+      - ${{ parameters.mandatoryTasks }}
+
+      - template: ../steps/export-scripts-path.yaml
+
+      - checkout: self
+        path: s
+        persistCredentials: true
+
+      - task: Bash@3
+        displayName: Install Software
+        inputs:
+          filePath: $(Framework.Config.PathToScripts)/oas2apigee/install-software.sh
+
+      - task: Bash@3
+        displayName: Generate SA Key File
+        inputs:
+          filePath: $(Framework.Config.PathToScripts)/sa-key-manager.sh
+          arguments: generate
+        env:
+          GCP_SA: $(gcpServiceAccount)
+
+      - task: Bash@3
+        displayName: Create API Proxy
+        inputs:
+          filePath: $(Framework.Config.PathToScripts)/oas2apigee/create-proxy.sh
+        env:
+          SA_PATH: ./sa.json
+
+      - task: Bash@3
+        name: ArtifactsStagingStep
+        displayName: Artifacts Staging
+        inputs:
+          filePath: $(Framework.Config.PathToScripts)/oas2apigee/artifacts-staging.sh
+
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish: OAS2Apigee Artifacts"
+        inputs:
+          pathToPublish: $(Build.ArtifactStagingDirectory)/oas2apigee-artifacts
+          artifactName: oas2apigee-artifacts
+
+      - task: Bash@3
+        displayName: Delete SA Key File
+        condition: always()
+        inputs:
+          filePath: $(Framework.Config.PathToScripts)/sa-key-manager.sh
+          arguments: delete
+
+      - task: Bash@3
+        displayName: Artifacts Cleaning
+        condition: always()
+        inputs:
+          filePath: $(Framework.Config.PathToScripts)/clean-artifact.sh
+          arguments: -a oas2apigee-artifacts

--- a/jobs/sca.yaml
+++ b/jobs/sca.yaml
@@ -51,6 +51,12 @@ jobs:
                 inputs:
                   filePath: $(Framework.Config.PathToScripts)/eslint-scan.sh
 
+      - ${{ if eq(parameters.buildProfile.name, 'oas2apigee') }}:
+          - task: Bash@3
+            displayName: "SCA: OpenAPI Specs"
+            inputs:
+              filePath: $(Framework.Config.PathToScripts)/spectral-lint-scan.sh
+
       - task: PublishTestResults@2
         displayName: Consume SCA Results
         condition: always()

--- a/scripts/oas2apigee/artifacts-staging.sh
+++ b/scripts/oas2apigee/artifacts-staging.sh
@@ -3,9 +3,11 @@
 main() {
     readonly ADO_DEBUG_CMD="##[debug]"
     echo "${ADO_DEBUG_CMD}"creating "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
-    mkdir -p "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    mkdir -p "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/oas
     echo "${ADO_DEBUG_CMD}"copying "${PROXYNAME}".zip to "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
     cp ./"${PROXYNAME}".zip "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    echo "${ADO_DEBUG_CMD}"copying oas/"${OASFILENAME}" to "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/oas/"${OASFILENAME}"
+    cp oas/"${OASFILENAME}" "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/oas/
     echo "${ADO_DEBUG_CMD}"copying "${PROXYNAME}".json to "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
     cp ./"${PROXYNAME}".json "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
     if [[ -d test/integration || -d tests/integration ]]; then

--- a/scripts/oas2apigee/artifacts-staging.sh
+++ b/scripts/oas2apigee/artifacts-staging.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+main() {
+    readonly ADO_DEBUG_CMD="##[debug]"
+    echo "${ADO_DEBUG_CMD}"creating "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    mkdir -p "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    echo "${ADO_DEBUG_CMD}"copying "${PROXYNAME}".zip to "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    cp ./"${PROXYNAME}".zip "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    echo "${ADO_DEBUG_CMD}"copying "${PROXYNAME}".json to "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    cp ./"${PROXYNAME}".json "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts
+    if [[ -d test/integration || -d tests/integration ]]; then
+        echo "${ADO_DEBUG_CMD}"test/integration or tests/integration found
+        echo "${ADO_DEBUG_CMD}"creating "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/test/integration
+        mkdir -p "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/test/integration
+        echo "${ADO_DEBUG_CMD}"copying test/integration or tests/integration to "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/test/integration
+        cp -r test*/integration/* "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/test/integration
+        [[ -f package.json ]] && echo "${ADO_DEBUG_CMD}"copying package*.json to "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/ && cp package*.json "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/oas2apigee-artifacts/
+    fi
+}
+
+[[ "${0}" == "${BASH_SOURCE[0]}" ]] && main "${*}"

--- a/scripts/oas2apigee/create-proxy.sh
+++ b/scripts/oas2apigee/create-proxy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+main() {
+    readonly ADO_DEBUG_CMD="##[debug]"
+    echo "${ADO_DEBUG_CMD}"creating "${PROXYNAME}" API proxy..
+    ~/.apigeecli/bin/apigeecli apis create openapi \
+        -o "${ORG}" \
+        -a "${SA_PATH}" \
+        -n "${PROXYNAME}" \
+        -f oas/"${OASFILENAME}" \
+        --add-cors | jq >"${PROXYNAME}".json
+    jq <"${PROXYNAME}".json
+}
+
+[[ "${0}" == "${BASH_SOURCE[0]}" ]] && main "${*}"

--- a/scripts/oas2apigee/create-proxy.sh
+++ b/scripts/oas2apigee/create-proxy.sh
@@ -3,12 +3,25 @@
 main() {
     readonly ADO_DEBUG_CMD="##[debug]"
     echo "${ADO_DEBUG_CMD}"creating "${PROXYNAME}" API proxy..
-    ~/.apigeecli/bin/apigeecli apis create openapi \
-        -o "${ORG}" \
-        -a "${SA_PATH}" \
-        -n "${PROXYNAME}" \
-        -f oas/"${OASFILENAME}" \
-        --add-cors | jq >"${PROXYNAME}".json
+    if [[ -z "${INITIALTARGETENDPOINT}" ]]; then
+        echo "${ADO_DEBUG_CMD}"target endpoint: https://"$(grep -m 1 '\- url' oas/"${OASFILENAME}" | cut -d/ -f3)"
+        ~/.apigeecli/bin/apigeecli apis create openapi \
+            -o "${ORG}" \
+            -a "${SA_PATH}" \
+            -n "${PROXYNAME}" \
+            -f oas/"${OASFILENAME}" \
+            --add-cors | jq >"${PROXYNAME}".json
+    else
+        echo "${ADO_DEBUG_CMD}"target endpoint: "${INITIALTARGETENDPOINT}"
+        ~/.apigeecli/bin/apigeecli apis create openapi \
+            -o "${ORG}" \
+            -a "${SA_PATH}" \
+            -n "${PROXYNAME}" \
+            -f oas/"${OASFILENAME}" \
+            --target-url "${INITIALTARGETENDPOINT}" \
+            --add-cors | jq >"${PROXYNAME}".json
+    fi
+
     jq <"${PROXYNAME}".json
 }
 

--- a/scripts/oas2apigee/install-software.sh
+++ b/scripts/oas2apigee/install-software.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+main() {
+    sudo apt-get install -y jq
+    curl -L https://raw.githubusercontent.com/apigee/apigeecli/main/downloadLatest.sh | sh -
+}
+
+[[ "${0}" == "${BASH_SOURCE[0]}" ]] && main "${*}"

--- a/scripts/spectral-lint-scan.sh
+++ b/scripts/spectral-lint-scan.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+main() {
+    mkdir -p "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/sca
+    readonly ADO_DEBUG_CMD="##[debug]"
+    echo "${ADO_DEBUG_CMD}searching for .spectral.yaml.."
+    if [ ! -f "./.spectral.yaml" ]; then
+        echo "${ADO_DEBUG_CMD}.spectral.yaml file not found"
+        echo "${ADO_DEBUG_CMD}generating basic .spectral.yaml with \"spectral:oas\" built-in ruleset"
+        cat <<EOF >.spectral.yaml
+---
+extends: "spectral:oas"
+EOF
+    else
+        echo "${ADO_DEBUG_CMD}.spectral.yaml found"
+    fi
+
+    echo "./node_modules/.bin/spectral lint --quiet ./oas/*.{json,yml,yaml} --fail-severity warn -f junit -o ${BUILD_ARTIFACTSTAGINGDIRECTORY}/sca/spectral-lint-out.xml"
+    ./node_modules/.bin/spectral lint --quiet "./oas/*.{json,yml,yaml}" -f junit --fail-severity warn -o "${BUILD_ARTIFACTSTAGINGDIRECTORY}"/sca/spectral-lint-out.xml || true # avoid flow breaking in case linting raises error
+}
+
+[[ "${0}" == "${BASH_SOURCE[0]}" ]] && main "${*}"


### PR DESCRIPTION
I am happy to announce that I have developed **'oas2apigee'** build profile within the pipeline templates following this approach:

- A change made to the working tree will trigger a build pipeline which will perform:
    - Static code analysis using **Spectral** on the given **oas/** directory.
    - The pipeline will fail on static code analysis failures.
    - The pipeline will create an API proxy on Apigee org with the default **servers[0].url** as the target endpoint (in my opinion, the build pipeline should not create an API proxy but we were required to do so), and it will attach the '**Add CORS'** policy **by default**.
    - The end user will have to provide the desired proxy name on his organization, a suggested name which follows both naming conventions and Apigee best practices: <company_name>-<api_name>-<api_version>.
    - The end user will have to provide the desired OAS file name to be deployed, the pipeline will append the provided name to **./oas/**
    - The build pipeline will publish the tests results to Azure DevOps server.
    - The build pipeline will produce an artifact containing:
        - API proxy bundle zip file
        - <proxy_name>.json     // apigeecli creation command output
        - oas/<oas_filename>   // needed by the release pipeline to update the target endpoint
        - integration test scripts.
        - package.json
        - package-lock.json

- A successful build run on the master/main branch will trigger a release pipeline which will:
    - Deploy to different environments determined by the stages provided by the end user.
    - Each stage will involve two jobs: 
        - Updating the created API proxy with a new target endpoint specific for the given environment and is specified by the tenant.
        - Deploying the API proxy new revision to the provided Apigee environment, overriding current deployed revision *-if exists-*.
        - Downloading the build artifact to use the integration testing scripts to execute functional testing using **apickli** + **CucumberJS**.
        - Tests results will be made visible to the **'tests'** tab.
        - Pipeline will fail on functional testing failures.