### PR TITLE
fix: modify scripts resource ref to v2.0.0-beta to avoid future errors

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -26,7 +26,7 @@ resources:
     - repository: scripts
       type: github
       name: ShehabEl-DeenAlalkamy/apigee-core-yaml-pipeline-templates
-      ref: main
+      ref: refs/tags/v2.0.0-beta
       endpoint: ShehabEl-DeenAlalkamy
 
 extends:

--- a/release.yaml
+++ b/release.yaml
@@ -29,7 +29,7 @@ resources:
     - repository: scripts
       type: github
       name: ShehabEl-DeenAlalkamy/apigee-core-yaml-pipeline-templates
-      ref: main
+      ref: refs/tags/v2.0.0-beta
       endpoint: ShehabEl-DeenAlalkamy
 
 variables:


### PR DESCRIPTION
I updated scripts resource in `build.yaml` & `release.yaml` to `refs/tags/v2.0.0-beta` to avoid backward compatibility issues in the future when new releases are made and other solutions reference this tag.

I am not sure whether if it will work, but it should work. This is a test and an extension to #7  